### PR TITLE
Update Segment.ts

### DIFF
--- a/src/Segment.ts
+++ b/src/Segment.ts
@@ -77,8 +77,15 @@ export namespace Segment {
 			const [ux, uy] = u
 			const [vx, vy] = v
 			const sign = ux * vy - uy * vx >= 0 ? 1 : -1
+			
+			const a = Math.acos(vec2.dot(u, v) / (vec2.sqrLen(u) * vec2.sqrLen(v)));
+			// Handle invalid angle by returning a default value
+			if (isNaN(a) || a < 0 || a > Math.PI) {
+				return Math.PI;
+			}
+			
 			return (
-				sign * Math.acos(vec2.dot(u, v) / (vec2.sqrLen(u) * vec2.sqrLen(v)))
+				sign * a
 			)
 		}
 


### PR DESCRIPTION
arcCommandToCenterParameterization's endAngle gets NaN values in some cases. The calculated angle in vec2Angle returns NaN. Which messes with the arcCommandToCenterParameterization function that is used in toPaperPath.

To handle this case, adding an if statement check seems to fix it.